### PR TITLE
Support for drf - Add missing attributes to MoneyField object

### DIFF
--- a/django_prices/models.py
+++ b/django_prices/models.py
@@ -31,6 +31,10 @@ class NonDatabaseFieldBase:
     one_to_many = None
     one_to_one = None
 
+    unique_for_date = None
+    unique_for_month = None
+    unique_for_year = None
+
     def __init__(self):
         self.column = None
         self.primary_key = False


### PR DESCRIPTION
Trying to `PUT/PATCH` object which uses `MoneyField` throws error:

```
File ".../lib/python3.9/site-packages/rest_framework/serializers.py", line 1604, in get_unique_for_date_validators
    if field.unique_for_date and field_name in field_names:
AttributeError: 'MoneyField' object has no attribute 'unique_for_date'
```

It seems that DRF needs following attributes on model instance:

- unique_for_date
- unique_for_month
- unique_for_year


I didn't find any information and solution for this error but error was very similar to error fixed in other PR  - https://github.com/TangoAgency/django-prices/pull/1

Changes tested locally and updating objects starts working properly.